### PR TITLE
Allow nesizm to compile on libfxcg 0.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifeq ($(strip $(FXCGSDK)),)
 export FXCGSDK := $(realpath ../../)
 endif
 
-include $(FXCGSDK)/common/prizm_rules
+include $(FXCGSDK)/toolchain/prizm_rules
 
 
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
Changes the path to prizm_rules in Makefile